### PR TITLE
Use libxdo instead of relying on shell + xdotool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
-CXXLAGS=-Os `pkg-config --cflags --libs libevdev`
+CXXFLAGS=-Os `pkg-config --cflags libevdev`
+LDFLAGS=`pkg-config --libs libevdev` -lxdo
 
-default: push-to-talk
+.PHONY: all clean
+
+all: push-to-talk
 
 push-to-talk: push-to-talk.cpp
-	gcc push-to-talk.cpp $(CXXLAGS) -o push-to-talk
 
 clean:
 	rm -f push-to-talk

--- a/README.md
+++ b/README.md
@@ -2,19 +2,18 @@
 This fixes the inability to use push to talk in Discord when running Wayland
 
 
-**NOTE: by default the left Meta (Windows) key is used for push to talk. In order to use a different key, change the `push-to-talk.sh` and `push-to-talk.cpp` files accordingly.**
+**NOTE: by default the left Meta (Windows) key is used for push to talk. In order to use a different key, change values for `PTT_EV_KEY_CODE` and `PTT_XKEY_CODE` in file `push-to-talk.c`.**
 
 ## Requirements
 
 Nothing special.
-- C++ compiler & Makefile
+- C++ compiler & Make
 - libevdev
-- `xdotool` shell tool
-- bash
+- libxdo (Debian/Ubuntu: `libxdo-dev`, Fedora/Centos: `libxdo-devel`)
 
 ## Approach
 
-Read specific key events via evdev (needs sudo) and then pass them to xdotool to inject key presses to all X apps.
+Read specific key events via evdev (needs sudo) and then pass them to libxdo to inject key presses to X apps.
 
 # Installation
 
@@ -22,7 +21,7 @@ Optimally we would install this as a user systemctl service (contributions welco
 
 ```
 make
-./push-to-talk.sh &
+sudo ./push-to-talk /dev/input/by-id/<device-name> &
 ```
 
 # License

--- a/push-to-talk.cpp
+++ b/push-to-talk.cpp
@@ -1,19 +1,38 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <libevdev/libevdev.h>
+extern "C" {
+  #include <xdo.h>
+}
 #include <unistd.h>
 #include <string.h>
 #include <stdlib.h>
 #include <errno.h>
 
+/* See https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h */
+#define PTT_EV_KEY_CODE KEY_LEFTMETA
+/*
+ * Full list (Ignore leading XKB_KEY_):
+ * https://github.com/xkbcommon/libxkbcommon/blob/master/include/xkbcommon/xkbcommon-keysyms.h
+ */
+#define PTT_XKEY_EVENT "Super_L"
+
 int main(int argc, char **argv)
 {
   struct libevdev *dev = NULL;
+  xdo_t *xdo;
   if (argc < 2) {
+    fprintf(stderr, "Usage: %s /dev/input/by-id/<device-name>\n", argv[0]);
     exit(0);
   }
 
   int fd = open(argv[1], O_RDONLY);
+  if (fd < 0) {
+    perror("Failed to open device");
+    if (getuid() != 0)
+      fprintf(stderr, "Fix permissions to %s or run as root\n", argv[1]);
+    exit(1);
+  }
   int rc = libevdev_new_from_fd(fd, &dev);
   if (rc < 0)
   {
@@ -26,21 +45,35 @@ int main(int argc, char **argv)
           libevdev_get_id_vendor(dev),
           libevdev_get_id_product(dev));
 
-  if (!libevdev_has_event_code(dev, EV_KEY, KEY_LEFTMETA)) {
-    printf("This device does not look like a keyboard\n");
+  if (!libevdev_has_event_code(dev, EV_KEY, PTT_EV_KEY_CODE)) {
+    fprintf(stderr, "This device is not capable of sending this key code\n");
+    exit(1);
+  }
+
+  xdo = xdo_new(NULL);
+  if (xdo == NULL) {
+    fprintf(stderr, "Failed to initialize xdo lib\n");
     exit(1);
   }
 
   do {
     struct input_event ev;
+
     rc = libevdev_next_event(dev, LIBEVDEV_READ_FLAG_NORMAL, &ev);
-    if (rc == 0) {
-      if (ev.type == EV_KEY && ev.code == KEY_LEFTMETA && ev.value != 2) {
-        printf("%s Super_L\n", ev.value == 1 ? "keydown" : "keyup");
-        fflush(stdout);
-      }
+    if (rc != LIBEVDEV_READ_STATUS_SUCCESS)
+      continue;
+
+    if (ev.type == EV_KEY && ev.code == PTT_EV_KEY_CODE && ev.value != 2) {
+      if (ev.value == 1)
+        xdo_send_keysequence_window_down(xdo, CURRENTWINDOW, PTT_XKEY_EVENT, 0);
+      else
+        xdo_send_keysequence_window_up(xdo, CURRENTWINDOW, PTT_XKEY_EVENT, 0);
     }
-  } while (rc == 1 || rc == 0 || rc == -EAGAIN);
+  } while (rc == LIBEVDEV_READ_STATUS_SYNC || rc == LIBEVDEV_READ_STATUS_SUCCESS || rc == -EAGAIN);
+
+  xdo_free(xdo);
+  libevdev_free(dev);
+  close(fd);
 
   return 0;
 }

--- a/push-to-talk.sh
+++ b/push-to-talk.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-exec sudo ./push-to-talk /dev/input/event2 | while read line; do xdotool $line;done


### PR DESCRIPTION
It's much more efficient to use libxdo tool rather than relying on the shell forking and execing xdotool for each event.

+ Use implicit Makefile rules.