### PR TITLE
Add command line arguments for verbose, keyname and keycode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This fixes the inability to use push to talk in Discord when running Wayland
 
 
-**NOTE: by default the left Meta (Windows) key is used for push to talk. In order to use a different key, change values for `PTT_EV_KEY_CODE` and `PTT_XKEY_CODE` in file `push-to-talk.c`.**
+**NOTE: by default the left Meta (Windows) key is used for push to talk. In order to use a different key, see the configuration section below.**
 
 ## Requirements
 
@@ -14,6 +14,12 @@ Nothing special.
 ## Approach
 
 Read specific key events via evdev (needs sudo) and then pass them to libxdo to inject key presses to X apps.
+
+# Configuration
+The command supports three command line args.
+- `-v`: verbose mode, logs all keystrokes
+- `-k`: keycode to listen for. [Full list](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h).
+- `-n`: keycode to send to discord. [Full list](https://github.com/xkbcommon/libxkbcommon/blob/master/include/xkbcommon/xkbcommon-keysyms.h) (ignore leading `XKB_KEY_`).
 
 # Installation
 


### PR DESCRIPTION
```
$ push-to-talk /dev/input/by-id/usb-Kinesis_Advantage2_Keyboard_314159265359-if01-event-kbd -v -k KEY_LEFTALT -n Alt_L
Input device name: "Kinesis Advantage2 Keyboard"
Input device ID: bus 0x3 vendor 0x29ea product 0x102
Listening for code KEY_LEFTALT, sending Alt_L
key up
key down
key up
```
