### PR TITLE
Add XDG Autostart Desktop file and install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ push-to-talk: push-to-talk.cpp
 
 clean:
 	rm -f push-to-talk
+
+install:
+	install -m 755 push-to-talk /usr/bin
+	install -m 644 push-to-talk.desktop /etc/xdg/autostart

--- a/README.md
+++ b/README.md
@@ -17,12 +17,24 @@ Read specific key events via evdev (needs sudo) and then pass them to libxdo to 
 
 # Installation
 
-Optimally we would install this as a user systemctl service (contributions welcome) but for now you will need to build this and run in the background with the `&` background operator.
+## Manual run
 
 ```
 make
-sudo ./push-to-talk /dev/input/by-id/<device-name> &
+sudo ./push-to-talk /dev/input/by-id/<device-id> &
 ```
+
+## Autostart
+
+First edit the `push-to-talk.desktop` file and replace `/dev/input/by-id/<device-id>` with your device path. Then:
+```
+make
+sudo make install
+
+# to allow you access `/dev/input` devices without root
+sudo usermod -aG input <your username>
+```
+Then just log out and log in. A process named `push-to-talk` should be running (visible in any process monitor).
 
 # License
 

--- a/push-to-talk.desktop
+++ b/push-to-talk.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Terminal=false
+Name=Discord Push-to-Talk
+GenericName=Discord Push-to-Talk
+Comment=A workaround app that allows using push-to-talk keybinding in Discord on Wayland
+Exec=/usr/bin/push-to-talk /dev/input/by-id/<device-id>


### PR DESCRIPTION
This pull request contains all changes needed to simply run this fix at login. It uses XDG Autostart Desktop specification to achieve that.

About systemd method:
I've tried at the beggining to create a systemd unit file but it seems like it isn't as simple as that to get access to Xserver from the context of systemd unit. The closest I could get is to use user-scoped service but program run too soon before Xserver initialization and there were isues with XDISPLAY and XAUTHORITY variables (even when defined manually).

I found [some discussion](https://superuser.com/questions/759759/writing-a-service-that-depends-on-xorg) about making it work so I suspect there is a way but this started to look overengineered which I don't like.

Last version of template unit if anyone would like to try:
```
# Run as push-to-talk@<device-id> where <device-id> is the id of the input device

[Unit]
Description=Wayland workaround for Discord push-to-talk global keybind
PartOf=graphical-session.target

[Service]
Type=simple
ExecStart=/usr/bin/push-to-talk /dev/input/by-id/%i
# %i could be replaced with %f to provide a full path to device
# but apparently systemd-escape doesn't like paths with hyphens so it won't work

[Install]
WantedBy=default.target
```