### PR TITLE
Makefile error: convert spaces to tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ LDFLAGS = $(shell pkg-config --libs libevdev) -lxdo
 all: push-to-talk
 
 push-to-talk: push-to-talk.cpp
-        $(CXX) $(CXXFLAGS) push-to-talk.cpp -o push-to-talk $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) push-to-talk.cpp -o push-to-talk $(LDFLAGS)
 
 clean:
-        rm -f push-to-talk
+	rm -f push-to-talk
 
 install:
-        install -m 755 push-to-talk /usr/bin
-        install -m 644 push-to-talk.desktop /etc/xdg/autostart
+	install -m 755 push-to-talk /usr/bin
+	install -m 644 push-to-talk.desktop /etc/xdg/autostart


### PR DESCRIPTION
The latest PR changed the indents to spaces, which produces the error when trying to build:

```
[jho@pows ~/tmp/wayland-push-to-talk-fix]
> make
Makefile:10: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop.
```

this PR converts them back to tabs so it can be built
```
[jho@pows ~/tmp/wayland-push-to-talk-fix]
> make
g++ -Os -I/usr/include/libevdev-1.0 push-to-talk.cpp -o push-to-talk -levdev -lxdo
```